### PR TITLE
Cross-platform fixes for binary

### DIFF
--- a/bin/delivery
+++ b/bin/delivery
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 require_once __DIR__ . '/../cjsDelivery.php';


### PR DESCRIPTION
The shebang line was hard-coded to `/usr/bin/php`, which isn't correct on a number of Linux distributions and OS X via `homebrew`. Using `/usr/bin/env php` is a platform-independent way of loading the PHP interpreter via a shebang, which is recommended for all POSIX systems.